### PR TITLE
feat: add particle-to-shell binning functionality with HEALPix maps

### DIFF
--- a/examples/shell_creation_example.py
+++ b/examples/shell_creation_example.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Example: Creating density shells from N-body simulation particles
+
+This example demonstrates how to use JaxRT to bin dark matter particles
+from N-body simulations onto spherical shells and convert them to HEALPix maps
+for gravitational lensing ray tracing.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import matplotlib.pyplot as plt
+import healpy as hp
+from astropy.cosmology import FlatLambdaCDM
+
+from jaxrt import create_density_shells_from_particles, convert_shells_to_convergence
+
+
+def create_mock_simulation_data(n_particles=10000, box_size=200.0):
+    """
+    Create mock N-body simulation data for demonstration.
+    
+    Parameters
+    ----------
+    n_particles : int
+        Number of dark matter particles
+    box_size : float
+        Size of simulation box in Mpc/h
+        
+    Returns
+    -------
+    positions : jnp.ndarray
+        Particle positions in Mpc/h
+    masses : jnp.ndarray
+        Particle masses in Msun/h
+    """
+    rng = np.random.RandomState(42)
+    
+    # Create clustered particle distribution
+    n_clusters = 20
+    cluster_centers = rng.uniform(-box_size/2, box_size/2, (n_clusters, 3))
+    cluster_sizes = rng.uniform(5, 15, n_clusters)
+    particles_per_cluster = n_particles // n_clusters
+    
+    positions = []
+    masses = []
+    
+    for i in range(n_clusters):
+        # Generate particles around cluster center
+        cluster_pos = rng.normal(
+            cluster_centers[i], 
+            cluster_sizes[i], 
+            (particles_per_cluster, 3)
+        )
+        positions.append(cluster_pos)
+        
+        # Mass follows rough power law
+        cluster_masses = rng.lognormal(
+            mean=np.log(1e11), 
+            sigma=0.5, 
+            size=particles_per_cluster
+        )
+        masses.append(cluster_masses)
+    
+    # Add remaining particles randomly
+    remaining = n_particles - n_clusters * particles_per_cluster
+    if remaining > 0:
+        random_pos = rng.uniform(-box_size/2, box_size/2, (remaining, 3))
+        random_masses = rng.lognormal(mean=np.log(1e10), sigma=0.3, size=remaining)
+        positions.append(random_pos)
+        masses.append(random_masses)
+    
+    positions = jnp.array(np.vstack(positions))
+    masses = jnp.array(np.concatenate(masses))
+    
+    return positions, masses
+
+
+def main():
+    """Main example execution."""
+    print("JaxRT Shell Creation Example")
+    print("=" * 40)
+    
+    # Set up cosmology
+    cosmology = FlatLambdaCDM(H0=70, Om0=0.3)
+    print(f"Using cosmology: {cosmology}")
+    
+    # Create mock simulation data
+    print("\n1. Creating mock N-body simulation data...")
+    positions, masses = create_mock_simulation_data(n_particles=50000, box_size=300.0)
+    print(f"   Created {len(positions)} particles")
+    print(f"   Position range: [{jnp.min(positions):.1f}, {jnp.max(positions):.1f}] Mpc/h")
+    print(f"   Mass range: [{jnp.min(masses):.2e}, {jnp.max(masses):.2e}] Msun/h")
+    
+    # Set observer position (typically at simulation box edge)
+    observer_position = jnp.array([-150.0, 0.0, 0.0])  # Mpc/h
+    print(f"   Observer position: {observer_position} Mpc/h")
+    
+    # Define shell parameters
+    shell_distances = jnp.array([50.0, 100.0, 150.0, 200.0, 250.0])  # Mpc/h
+    shell_thickness = 20.0  # Mpc/h
+    nside = 128  # HEALPix resolution (higher = more detailed)
+    
+    print(f"\n2. Creating {len(shell_distances)} density shells...")
+    print(f"   Shell distances: {shell_distances} Mpc/h")
+    print(f"   Shell thickness: {shell_thickness} Mpc/h") 
+    print(f"   HEALPix nside: {nside} (npix = {12 * nside**2})")
+    
+    # Create density shells
+    shell_maps, shell_redshifts = create_density_shells_from_particles(
+        particle_positions=positions,
+        particle_masses=masses,
+        observer_position=observer_position,
+        shell_distances=shell_distances,
+        shell_thickness=shell_thickness,
+        nside=nside,
+        cosmology=cosmology
+    )
+    
+    print(f"   Successfully created shells with shape: {shell_maps.shape}")
+    print(f"   Shell redshifts: {shell_redshifts}")
+    
+    # Analyze shell properties
+    print(f"\n3. Analyzing shell properties...")
+    for i, (dist, z) in enumerate(zip(shell_distances, shell_redshifts)):
+        shell_map = shell_maps[i]
+        total_mass = jnp.sum(shell_map) * (4 * jnp.pi * dist**2) / (12 * nside**2)
+        n_pixels_with_mass = jnp.sum(shell_map > 0)
+        max_density = jnp.max(shell_map)
+        
+        print(f"   Shell {i}: z={z:.3f}, total_mass={total_mass:.2e} Msun/h")
+        print(f"            {n_pixels_with_mass}/{12*nside**2} pixels have mass")
+        print(f"            max surface density={max_density:.2e} Msun/h/(Mpc/h)²")
+    
+    # Convert to convergence maps for lensing
+    source_redshift = 1.0
+    print(f"\n4. Converting to convergence for source at z = {source_redshift}...")
+    
+    convergence_maps = convert_shells_to_convergence(
+        shell_maps, shell_redshifts, source_redshift, cosmology
+    )
+    
+    for i, z in enumerate(shell_redshifts):
+        if z < source_redshift:
+            max_kappa = jnp.max(convergence_maps[i])
+            print(f"   Shell {i} (z={z:.3f}): max convergence = {max_kappa:.4f}")
+        else:
+            print(f"   Shell {i} (z={z:.3f}): behind source, convergence = 0")
+    
+    # Visualization
+    print(f"\n5. Creating visualizations...")
+    
+    # Plot 2 shells for demonstration
+    fig, axes = plt.subplots(2, 2, figsize=(12, 10))
+    fig.suptitle('JaxRT Shell Creation Example', fontsize=16)
+    
+    for i in range(min(2, len(shell_maps))):
+        # Surface density map
+        hp.mollview(
+            np.array(shell_maps[i]), 
+            title=f'Shell {i}: Surface Density (z={shell_redshifts[i]:.3f})',
+            unit='Msun/h/(Mpc/h)²',
+            sub=(2, 2, 2*i + 1),
+            cmap='viridis'
+        )
+        
+        # Convergence map
+        if shell_redshifts[i] < source_redshift:
+            hp.mollview(
+                np.array(convergence_maps[i]),
+                title=f'Shell {i}: Convergence (z={shell_redshifts[i]:.3f})',
+                unit='κ',
+                sub=(2, 2, 2*i + 2),
+                cmap='RdBu_r'
+            )
+        else:
+            # Empty plot for shells behind source
+            ax = plt.subplot(2, 2, 2*i + 2)
+            ax.text(0.5, 0.5, f'Shell behind source\n(z={shell_redshifts[i]:.3f} > {source_redshift})',
+                   ha='center', va='center', transform=ax.transAxes, fontsize=12)
+            ax.set_xticks([])
+            ax.set_yticks([])
+    
+    plt.tight_layout()
+    
+    # Save results
+    print(f"\n6. Saving results...")
+    
+    # Save plots
+    plot_filename = 'shell_creation_example.png'
+    plt.savefig(plot_filename, dpi=150, bbox_inches='tight')
+    print(f"   Saved plot: {plot_filename}")
+    
+    # Save shell data (optional - commented out to avoid large files)
+    # from jaxrt import save_shells_to_fits
+    # save_shells_to_fits(shell_maps, 'density_shells', shell_redshifts)
+    # print(f"   Saved FITS files: density_shells_shell_*.fits")
+    
+    print(f"\n✓ Example completed successfully!")
+    print(f"  Created {len(shell_maps)} density shells from {len(positions)} particles")
+    print(f"  Generated HEALPix maps with nside={nside} ({12*nside**2} pixels each)")
+    print(f"  Computed convergence maps for source at z={source_redshift}")
+    
+    return shell_maps, shell_redshifts, convergence_maps
+
+
+if __name__ == "__main__":
+    # Set up matplotlib for non-interactive use
+    import matplotlib
+    matplotlib.use('Agg')  # Use non-GUI backend
+    
+    # Run example
+    try:
+        shell_maps, shell_redshifts, convergence_maps = main()
+        print("\nExample data available in variables: shell_maps, shell_redshifts, convergence_maps")
+    except ImportError as e:
+        print(f"Missing dependency: {e}")
+        print("Please install all required packages: pip install -e .")
+    except Exception as e:
+        print(f"Error running example: {e}")
+        raise

--- a/examples/shell_creation_example.py
+++ b/examples/shell_creation_example.py
@@ -11,7 +11,7 @@ import jax.numpy as jnp
 import numpy as np
 import matplotlib.pyplot as plt
 import healpy as hp
-from astropy.cosmology import FlatLambdaCDM
+import jax_cosmo as jc
 
 from jaxrt import create_density_shells_from_particles, convert_shells_to_convergence
 
@@ -82,8 +82,8 @@ def main():
     print("=" * 40)
     
     # Set up cosmology
-    cosmology = FlatLambdaCDM(H0=70, Om0=0.3)
-    print(f"Using cosmology: {cosmology}")
+    cosmology = jc.Planck15()
+    print(f"Using cosmology: jax-cosmo Planck15")
     
     # Create mock simulation data
     print("\n1. Creating mock N-body simulation data...")
@@ -118,7 +118,7 @@ def main():
     )
     
     print(f"   Successfully created shells with shape: {shell_maps.shape}")
-    print(f"   Shell redshifts: {shell_redshifts}")
+    print(f"   Shell redshifts: {np.array(shell_redshifts)}")
     
     # Analyze shell properties
     print(f"\n3. Analyzing shell properties...")
@@ -128,9 +128,9 @@ def main():
         n_pixels_with_mass = jnp.sum(shell_map > 0)
         max_density = jnp.max(shell_map)
         
-        print(f"   Shell {i}: z={z:.3f}, total_mass={total_mass:.2e} Msun/h")
-        print(f"            {n_pixels_with_mass}/{12*nside**2} pixels have mass")
-        print(f"            max surface density={max_density:.2e} Msun/h/(Mpc/h)²")
+        print(f"   Shell {i}: z={float(z):.3f}, total_mass={float(total_mass):.2e} Msun/h")
+        print(f"            {int(n_pixels_with_mass)}/{12*nside**2} pixels have mass")
+        print(f"            max surface density={float(max_density):.2e} Msun/h/(Mpc/h)²")
     
     # Convert to convergence maps for lensing
     source_redshift = 1.0
@@ -143,9 +143,9 @@ def main():
     for i, z in enumerate(shell_redshifts):
         if z < source_redshift:
             max_kappa = jnp.max(convergence_maps[i])
-            print(f"   Shell {i} (z={z:.3f}): max convergence = {max_kappa:.4f}")
+            print(f"   Shell {i} (z={float(z):.3f}): max convergence = {float(max_kappa):.4f}")
         else:
-            print(f"   Shell {i} (z={z:.3f}): behind source, convergence = 0")
+            print(f"   Shell {i} (z={float(z):.3f}): behind source, convergence = 0")
     
     # Visualization
     print(f"\n5. Creating visualizations...")
@@ -158,7 +158,7 @@ def main():
         # Surface density map
         hp.mollview(
             np.array(shell_maps[i]), 
-            title=f'Shell {i}: Surface Density (z={shell_redshifts[i]:.3f})',
+            title=f'Shell {i}: Surface Density (z={float(shell_redshifts[i]):.3f})',
             unit='Msun/h/(Mpc/h)²',
             sub=(2, 2, 2*i + 1),
             cmap='viridis'
@@ -168,7 +168,7 @@ def main():
         if shell_redshifts[i] < source_redshift:
             hp.mollview(
                 np.array(convergence_maps[i]),
-                title=f'Shell {i}: Convergence (z={shell_redshifts[i]:.3f})',
+                title=f'Shell {i}: Convergence (z={float(shell_redshifts[i]):.3f})',
                 unit='κ',
                 sub=(2, 2, 2*i + 2),
                 cmap='RdBu_r'
@@ -176,7 +176,7 @@ def main():
         else:
             # Empty plot for shells behind source
             ax = plt.subplot(2, 2, 2*i + 2)
-            ax.text(0.5, 0.5, f'Shell behind source\n(z={shell_redshifts[i]:.3f} > {source_redshift})',
+            ax.text(0.5, 0.5, f'Shell behind source\n(z={float(shell_redshifts[i]):.3f} > {source_redshift})',
                    ha='center', va='center', transform=ax.transAxes, fontsize=12)
             ax.set_xticks([])
             ax.set_yticks([])

--- a/jaxrt/__init__.py
+++ b/jaxrt/__init__.py
@@ -13,10 +13,20 @@ from .core.born_convergence import (
     lensing_kernel
 )
 from .maps.convergence_map import ConvergenceMap
+from .planes.shells import (
+    create_density_shells_from_particles,
+    create_shells_from_lightcone,
+    convert_shells_to_convergence,
+    save_shells_to_fits,
+)
 
 __all__ = [
     "born_convergence",
     "born_convergence_from_cosmology",
     "lensing_kernel",
     "ConvergenceMap",
+    "create_density_shells_from_particles",
+    "create_shells_from_lightcone",
+    "convert_shells_to_convergence",
+    "save_shells_to_fits",
 ]

--- a/jaxrt/planes/__init__.py
+++ b/jaxrt/planes/__init__.py
@@ -1,5 +1,18 @@
 """Lens plane utilities for JaxRT."""
 
 from .density_plane import generate_gaussian_density_plane, create_density_planes_sequence
+from .shells import (
+    create_density_shells_from_particles,
+    create_shells_from_lightcone,
+    convert_shells_to_convergence,
+    save_shells_to_fits,
+)
 
-__all__ = ["generate_gaussian_density_plane", "create_density_planes_sequence"]
+__all__ = [
+    "generate_gaussian_density_plane",
+    "create_density_planes_sequence",
+    "create_density_shells_from_particles",
+    "create_shells_from_lightcone", 
+    "convert_shells_to_convergence",
+    "save_shells_to_fits",
+]

--- a/jaxrt/planes/shells.py
+++ b/jaxrt/planes/shells.py
@@ -1,0 +1,309 @@
+"""
+JAX-based particle binning onto spherical shells for ray tracing.
+
+This module provides functionality to bin dark matter particles from N-body
+simulations onto spherical shells and convert them to HEALPix maps for
+gravitational lensing ray tracing.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import healpy as hp
+from typing import Optional, Tuple, Union
+from astropy.cosmology import FLRW
+import astropy.units as u
+
+
+@jax.jit
+def _compute_distances(positions: jnp.ndarray, observer_position: jnp.ndarray) -> jnp.ndarray:
+    """Compute distances from observer to particles."""
+    delta = positions - observer_position
+    return jnp.sqrt(jnp.sum(delta**2, axis=1))
+
+
+@jax.jit
+def _bin_particles_to_shell(
+    positions: jnp.ndarray,
+    masses: jnp.ndarray,
+    observer_position: jnp.ndarray,
+    shell_distance: float,
+    shell_thickness: float,
+    nside: int,
+) -> jnp.ndarray:
+    """Bin particles to a single spherical shell."""
+    # Compute distances
+    distances = _compute_distances(positions, observer_position)
+    
+    # Find particles in shell
+    shell_min = shell_distance - shell_thickness / 2
+    shell_max = shell_distance + shell_thickness / 2
+    in_shell = (distances >= shell_min) & (distances <= shell_max)
+    
+    # Get shell particles
+    shell_positions = positions[in_shell]
+    shell_masses = masses[in_shell]
+    
+    if shell_positions.shape[0] == 0:
+        # No particles in shell
+        return jnp.zeros(12 * nside**2)
+    
+    # Convert to angular positions from observer
+    shell_vectors = shell_positions - observer_position
+    shell_distances = jnp.sqrt(jnp.sum(shell_vectors**2, axis=1))
+    shell_unit_vectors = shell_vectors / shell_distances[:, None]
+    
+    # Convert to theta, phi coordinates
+    theta = jnp.arccos(jnp.clip(shell_unit_vectors[:, 2], -1, 1))
+    phi = jnp.arctan2(shell_unit_vectors[:, 1], shell_unit_vectors[:, 0])
+    
+    # Convert to HEALPix pixel indices
+    ipix = hp.ang2pix(nside, theta, phi, nest=False)
+    
+    # Bin masses into pixels using scatter-add
+    npix = 12 * nside**2
+    surface_density = jnp.zeros(npix)
+    surface_density = surface_density.at[ipix].add(shell_masses)
+    
+    # Convert to surface density (mass per unit area)
+    # Shell area = 4π * r²
+    shell_area = 4 * jnp.pi * shell_distance**2
+    pixel_area = shell_area / npix
+    surface_density = surface_density / pixel_area
+    
+    return surface_density
+
+
+def create_density_shells_from_particles(
+    particle_positions: jnp.ndarray,
+    particle_masses: jnp.ndarray,
+    observer_position: jnp.ndarray,
+    shell_distances: jnp.ndarray,
+    shell_thickness: float,
+    nside: int,
+    cosmology: Optional[FLRW] = None,
+) -> Tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+    """
+    Create density shells from N-body simulation particles.
+    
+    Parameters
+    ----------
+    particle_positions : jnp.ndarray
+        Particle positions with shape (N_particles, 3) in Mpc/h
+    particle_masses : jnp.ndarray
+        Particle masses with shape (N_particles,) in Msun/h
+    observer_position : jnp.ndarray
+        Observer position with shape (3,) in Mpc/h
+    shell_distances : jnp.ndarray
+        Shell distances from observer in Mpc/h
+    shell_thickness : float
+        Thickness of each shell in Mpc/h
+    nside : int
+        HEALPix resolution parameter
+    cosmology : astropy.cosmology.FLRW, optional
+        Cosmology object for distance-redshift conversion
+        
+    Returns
+    -------
+    shell_maps : jnp.ndarray
+        Surface density maps for each shell with shape (n_shells, 12*nside**2)
+        in units of Msun/h per (Mpc/h)²
+    shell_redshifts : jnp.ndarray, optional
+        Redshifts corresponding to shell distances (if cosmology provided)
+    """
+    n_shells = len(shell_distances)
+    npix = 12 * nside**2
+    
+    # Initialize output arrays
+    shell_maps = jnp.zeros((n_shells, npix))
+    
+    # Process each shell
+    for i, shell_distance in enumerate(shell_distances):
+        shell_map = _bin_particles_to_shell(
+            particle_positions,
+            particle_masses,
+            observer_position,
+            shell_distance,
+            shell_thickness,
+            nside,
+        )
+        shell_maps = shell_maps.at[i].set(shell_map)
+    
+    # Convert distances to redshifts if cosmology provided
+    shell_redshifts = None
+    if cosmology is not None:
+        # Convert comoving distance to redshift
+        distances_with_units = shell_distances * u.Mpc / cosmology.h
+        shell_redshifts = jnp.array([
+            cosmology.z_at_value(cosmology.comoving_distance, d)
+            for d in distances_with_units
+        ])
+    
+    return shell_maps, shell_redshifts
+
+
+def create_shells_from_lightcone(
+    particle_positions: jnp.ndarray,
+    particle_masses: jnp.ndarray,
+    particle_redshifts: jnp.ndarray,
+    observer_position: jnp.ndarray,
+    shell_redshifts: jnp.ndarray,
+    redshift_thickness: float,
+    nside: int,
+    cosmology: FLRW,
+) -> jnp.ndarray:
+    """
+    Create density shells from lightcone simulation particles using redshift binning.
+    
+    Parameters
+    ----------
+    particle_positions : jnp.ndarray
+        Particle positions with shape (N_particles, 3) in Mpc/h
+    particle_masses : jnp.ndarray
+        Particle masses with shape (N_particles,) in Msun/h
+    particle_redshifts : jnp.ndarray
+        Particle redshifts with shape (N_particles,)
+    observer_position : jnp.ndarray
+        Observer position with shape (3,) in Mpc/h
+    shell_redshifts : jnp.ndarray
+        Shell redshifts for binning
+    redshift_thickness : float
+        Thickness of each redshift shell
+    nside : int
+        HEALPix resolution parameter
+    cosmology : astropy.cosmology.FLRW
+        Cosmology object for distance calculations
+        
+    Returns
+    -------
+    shell_maps : jnp.ndarray
+        Surface density maps for each shell with shape (n_shells, 12*nside**2)
+    """
+    n_shells = len(shell_redshifts)
+    npix = 12 * nside**2
+    shell_maps = jnp.zeros((n_shells, npix))
+    
+    for i, shell_z in enumerate(shell_redshifts):
+        # Find particles in redshift shell
+        z_min = shell_z - redshift_thickness / 2
+        z_max = shell_z + redshift_thickness / 2
+        in_shell = (particle_redshifts >= z_min) & (particle_redshifts <= z_max)
+        
+        if jnp.sum(in_shell) == 0:
+            continue
+            
+        shell_positions = particle_positions[in_shell]
+        shell_masses = particle_masses[in_shell]
+        
+        # Compute shell distance from cosmology
+        shell_distance = cosmology.comoving_distance(shell_z).to(u.Mpc).value * cosmology.h
+        
+        # Create shell map
+        shell_map = _bin_particles_to_shell(
+            shell_positions,
+            shell_masses,
+            observer_position,
+            shell_distance,
+            redshift_thickness * shell_distance / shell_z,  # Approximate thickness in Mpc/h
+            nside,
+        )
+        shell_maps = shell_maps.at[i].set(shell_map)
+    
+    return shell_maps
+
+
+def convert_shells_to_convergence(
+    shell_maps: jnp.ndarray,
+    shell_redshifts: jnp.ndarray,
+    source_redshift: float,
+    cosmology: FLRW,
+) -> jnp.ndarray:
+    """
+    Convert surface density shells to convergence maps for weak lensing.
+    
+    Parameters
+    ----------
+    shell_maps : jnp.ndarray
+        Surface density maps with shape (n_shells, npix)
+    shell_redshifts : jnp.ndarray
+        Redshifts of the shells
+    source_redshift : float
+        Redshift of source galaxies
+    cosmology : astropy.cosmology.FLRW
+        Cosmology object
+        
+    Returns
+    -------
+    convergence_maps : jnp.ndarray
+        Convergence maps with shape (n_shells, npix)
+    """
+    # Critical surface density
+    c = 299792458  # m/s
+    G = 6.67430e-11  # m³ kg⁻¹ s⁻²
+    
+    # Convert units and compute critical surface density
+    critical_density = 3 * cosmology.H0**2 / (8 * jnp.pi * G)  # in proper units
+    
+    # Lensing efficiency
+    d_source = cosmology.angular_diameter_distance(source_redshift)
+    
+    convergence_maps = jnp.zeros_like(shell_maps)
+    
+    for i, shell_z in enumerate(shell_redshifts):
+        if shell_z >= source_redshift:
+            continue
+            
+        d_lens = cosmology.angular_diameter_distance(shell_z)
+        d_lens_source = cosmology.angular_diameter_distance_z1z2(shell_z, source_redshift)
+        
+        # Lensing efficiency
+        lensing_efficiency = d_lens * d_lens_source / d_source
+        
+        # Convert surface density to convergence
+        sigma_crit = critical_density * d_source / (d_lens * d_lens_source)
+        convergence_maps = convergence_maps.at[i].set(
+            shell_maps[i] / sigma_crit * lensing_efficiency
+        )
+    
+    return convergence_maps
+
+
+def save_shells_to_fits(
+    shell_maps: jnp.ndarray,
+    filename: str,
+    shell_redshifts: Optional[jnp.ndarray] = None,
+    nest: bool = False,
+) -> None:
+    """
+    Save shell maps to FITS files.
+    
+    Parameters
+    ----------
+    shell_maps : jnp.ndarray
+        Shell maps with shape (n_shells, npix)
+    filename : str
+        Base filename (shell index will be appended)
+    shell_redshifts : jnp.ndarray, optional
+        Redshifts for each shell
+    nest : bool
+        Whether maps use NEST ordering
+    """
+    n_shells = shell_maps.shape[0]
+    
+    for i in range(n_shells):
+        shell_filename = f"{filename}_shell_{i:03d}.fits"
+        
+        # Create header with metadata
+        header = {}
+        if shell_redshifts is not None:
+            header['REDSHIFT'] = float(shell_redshifts[i])
+        header['SHELL_ID'] = i
+        
+        # Save map
+        hp.write_map(
+            shell_filename,
+            np.array(shell_maps[i]),
+            nest=nest,
+            coord='C',
+            extra_header=header,
+        )

--- a/jaxrt/planes/shells.py
+++ b/jaxrt/planes/shells.py
@@ -21,7 +21,6 @@ def _compute_distances(positions: jnp.ndarray, observer_position: jnp.ndarray) -
     return jnp.sqrt(jnp.sum(delta**2, axis=1))
 
 
-@jax.jit
 def _bin_particles_to_shell(
     positions: jnp.ndarray,
     masses: jnp.ndarray,
@@ -95,7 +94,6 @@ def _validate_inputs(
         raise ValueError("Shell distances must be positive")
 
 
-@jax.jit 
 def _bin_all_shells(
     positions: jnp.ndarray,
     masses: jnp.ndarray, 
@@ -173,7 +171,6 @@ def create_density_shells_from_particles(
     return shell_maps, shell_redshifts
 
 
-@jax.jit
 def _create_single_lightcone_shell(
     particle_positions: jnp.ndarray,
     particle_masses: jnp.ndarray,
@@ -266,7 +263,6 @@ def create_shells_from_lightcone(
     return shell_maps
 
 
-@jax.jit
 def _compute_single_convergence(
     shell_map: jnp.ndarray,
     shell_z: float,
@@ -277,10 +273,12 @@ def _compute_single_convergence(
     # Skip shells at or behind source
     def compute_convergence():
         # Angular diameter distances (in Mpc)
-        d_lens = jc.background.angular_diameter_distance(cosmology, 1.0 / (1.0 + shell_z))
-        d_source = jc.background.angular_diameter_distance(cosmology, 1.0 / (1.0 + source_redshift))
+        a_lens = 1.0 / (1.0 + shell_z)
+        a_source = 1.0 / (1.0 + source_redshift)
+        d_lens = jc.background.angular_diameter_distance(cosmology, a_lens)
+        d_source = jc.background.angular_diameter_distance(cosmology, a_source)
         d_lens_source = jc.background.angular_diameter_distance_z1z2(
-            cosmology, 1.0 / (1.0 + shell_z), 1.0 / (1.0 + source_redshift)
+            cosmology, a_lens, a_source
         )
         
         # Critical surface density using jax-cosmo constants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "numpy>=1.21.0",
     "scipy>=1.7.0",
     "jax-cosmo>=0.1.0",
-    "astropy>=5.0.0",
     "healpy>=1.16.0",
 ]
 
@@ -40,6 +39,7 @@ test = [
     "pytest>=6.0",
     "pytest-cov",
     "lenstools",  # For comparison tests
+    "astropy>=5.0.0",  # Required by LensTools for comparison tests
     "matplotlib>=3.5.0",  # For demo and visualization
 ]
 dev = [
@@ -50,6 +50,7 @@ dev = [
     "flake8",
     "mypy",
     "lenstools",
+    "astropy>=5.0.0",  # Required by LensTools for comparison tests
     "matplotlib>=3.5.0",
 ]
 ci = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "scipy>=1.7.0",
     "jax-cosmo>=0.1.0",
     "astropy>=5.0.0",
+    "healpy>=1.16.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ jaxlib>=0.4.0
 numpy>=1.21.0
 scipy>=1.7.0
 jax-cosmo>=0.1.0
-astropy>=5.0.0
 healpy>=1.16.0
 
 # Development and testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy>=1.21.0
 scipy>=1.7.0
 jax-cosmo>=0.1.0
 astropy>=5.0.0
+healpy>=1.16.0
 
 # Development and testing
 pytest>=6.0

--- a/tests/test_born_convergence.py
+++ b/tests/test_born_convergence.py
@@ -9,7 +9,7 @@ import numpy as np
 import jax.numpy as jnp
 import jax
 import pytest
-from astropy.units import deg, Mpc
+# JAX-cosmo units are used instead of astropy units
 
 # Import our JAX implementation
 import sys
@@ -164,9 +164,14 @@ class TestBornConvergence:
         # Setup LensTools RayTracer
         tracer = RayTracer(lens_mesh_size=params['resolution'])
         
-        # Add density planes to tracer
-        from astropy.cosmology import Planck18
-        cosmo = Planck18
+        # Add density planes to tracer - use astropy for LensTools compatibility
+        try:
+            from astropy.cosmology import Planck18
+            from astropy.units import deg
+            cosmo = Planck18
+        except ImportError:
+            # Fallback if astropy not available
+            pytest.skip("astropy required for LensTools comparison")
         
         for i, (density_map, z) in enumerate(zip(density_planes_np, redshifts)):
             # Create LensTools DensityPlane

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -3,7 +3,7 @@
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from astropy.cosmology import FlatLambdaCDM
+import jax_cosmo as jc
 
 from jaxrt.planes.shells import (
     create_density_shells_from_particles,
@@ -33,7 +33,16 @@ def mock_particles():
 @pytest.fixture
 def mock_cosmology():
     """Create mock cosmology for testing."""
-    return FlatLambdaCDM(H0=70, Om0=0.3)
+    return jc.Cosmology(
+        Omega_c=0.25,
+        Omega_b=0.05,
+        h=0.7,
+        sigma8=0.8,
+        n_s=0.96,
+        Omega_k=0.0,
+        w0=-1.0,
+        wa=0.0
+    )
 
 
 def test_compute_distances():

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -230,3 +230,29 @@ def test_observer_position_effect():
     
     # Results should be different
     assert not jnp.allclose(shell_map1, shell_map2)
+
+
+def test_input_validation():
+    """Test input validation functions."""
+    from jaxrt.planes.shells import _validate_inputs
+    
+    # Test negative masses
+    with pytest.raises(ValueError, match="non-negative"):
+        _validate_inputs(jnp.array([-1, 1]), 8, jnp.array([10.0]))
+    
+    # Test invalid nside
+    with pytest.raises(ValueError, match="power of 2"):
+        _validate_inputs(jnp.array([1, 1]), 7, jnp.array([10.0]))
+    
+    with pytest.raises(ValueError, match="power of 2"):
+        _validate_inputs(jnp.array([1, 1]), 0, jnp.array([10.0]))
+    
+    # Test non-positive distances
+    with pytest.raises(ValueError, match="positive"):
+        _validate_inputs(jnp.array([1, 1]), 8, jnp.array([0.0]))
+    
+    with pytest.raises(ValueError, match="positive"):
+        _validate_inputs(jnp.array([1, 1]), 8, jnp.array([-1.0]))
+    
+    # Test valid inputs (should not raise)
+    _validate_inputs(jnp.array([1, 1]), 8, jnp.array([10.0]))

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -1,0 +1,232 @@
+"""Tests for particle-to-shell binning functionality."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from astropy.cosmology import FlatLambdaCDM
+
+from jaxrt.planes.shells import (
+    create_density_shells_from_particles,
+    create_shells_from_lightcone,
+    convert_shells_to_convergence,
+    _compute_distances,
+    _bin_particles_to_shell,
+)
+
+
+@pytest.fixture
+def mock_particles():
+    """Create mock particle data for testing."""
+    # Create a simple distribution of particles
+    n_particles = 1000
+    rng = np.random.RandomState(42)
+    
+    # Random positions in a cube
+    positions = rng.uniform(-100, 100, (n_particles, 3))
+    
+    # Random masses
+    masses = rng.uniform(1e10, 1e12, n_particles)
+    
+    return jnp.array(positions), jnp.array(masses)
+
+
+@pytest.fixture
+def mock_cosmology():
+    """Create mock cosmology for testing."""
+    return FlatLambdaCDM(H0=70, Om0=0.3)
+
+
+def test_compute_distances():
+    """Test distance computation."""
+    positions = jnp.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    observer = jnp.array([0, 0, 0])
+    
+    distances = _compute_distances(positions, observer)
+    expected = jnp.array([0, 1, 1, 1])
+    
+    assert jnp.allclose(distances, expected)
+
+
+def test_bin_particles_to_shell(mock_particles):
+    """Test binning particles to a single shell."""
+    positions, masses = mock_particles
+    observer = jnp.array([0, 0, 0])
+    
+    # Create a shell at distance 50 with thickness 10
+    shell_map = _bin_particles_to_shell(
+        positions, masses, observer, 50.0, 10.0, nside=8
+    )
+    
+    # Check output shape
+    assert shell_map.shape == (12 * 8**2,)
+    
+    # Check that some pixels have non-zero values
+    assert jnp.sum(shell_map > 0) > 0
+    
+    # Check that total mass is conserved (approximately)
+    distances = _compute_distances(positions, observer)
+    in_shell = (distances >= 45) & (distances <= 55)
+    expected_total_mass = jnp.sum(masses[in_shell])
+    
+    # Total mass in shell map (need to account for surface density conversion)
+    shell_area = 4 * jnp.pi * 50.0**2
+    pixel_area = shell_area / (12 * 8**2)
+    total_mass_in_map = jnp.sum(shell_map) * pixel_area
+    
+    assert jnp.allclose(total_mass_in_map, expected_total_mass, rtol=1e-10)
+
+
+def test_create_density_shells_from_particles(mock_particles):
+    """Test creating density shells from particles."""
+    positions, masses = mock_particles
+    observer = jnp.array([0, 0, 0])
+    shell_distances = jnp.array([30.0, 60.0, 90.0])
+    
+    shell_maps, shell_redshifts = create_density_shells_from_particles(
+        positions, masses, observer, shell_distances, 10.0, nside=8
+    )
+    
+    # Check output shapes
+    assert shell_maps.shape == (3, 12 * 8**2)
+    assert shell_redshifts is None  # No cosmology provided
+    
+    # Check that all shells have some content
+    for i in range(3):
+        assert jnp.sum(shell_maps[i] > 0) > 0
+
+
+def test_create_density_shells_with_cosmology(mock_particles, mock_cosmology):
+    """Test creating density shells with cosmology."""
+    positions, masses = mock_particles
+    observer = jnp.array([0, 0, 0])
+    shell_distances = jnp.array([50.0, 100.0])
+    
+    shell_maps, shell_redshifts = create_density_shells_from_particles(
+        positions, masses, observer, shell_distances, 10.0, nside=8,
+        cosmology=mock_cosmology
+    )
+    
+    # Check that redshifts are computed
+    assert shell_redshifts is not None
+    assert len(shell_redshifts) == 2
+    assert jnp.all(shell_redshifts > 0)
+
+
+def test_create_shells_from_lightcone(mock_cosmology):
+    """Test creating shells from lightcone particles."""
+    # Create mock lightcone data
+    n_particles = 500
+    rng = np.random.RandomState(42)
+    
+    positions = jnp.array(rng.uniform(-50, 50, (n_particles, 3)))
+    masses = jnp.array(rng.uniform(1e10, 1e12, n_particles))
+    redshifts = jnp.array(rng.uniform(0.1, 2.0, n_particles))
+    
+    observer = jnp.array([0, 0, 0])
+    shell_redshifts = jnp.array([0.5, 1.0, 1.5])
+    
+    shell_maps = create_shells_from_lightcone(
+        positions, masses, redshifts, observer, shell_redshifts, 0.1, nside=8, 
+        cosmology=mock_cosmology
+    )
+    
+    # Check output shape
+    assert shell_maps.shape == (3, 12 * 8**2)
+
+
+def test_convert_shells_to_convergence(mock_cosmology):
+    """Test converting shells to convergence."""
+    # Create mock shell data
+    n_shells = 3
+    nside = 8
+    npix = 12 * nside**2
+    
+    shell_maps = jnp.ones((n_shells, npix)) * 1e12  # Surface density in Msun/h per (Mpc/h)²
+    shell_redshifts = jnp.array([0.3, 0.6, 0.9])
+    source_redshift = 1.2
+    
+    convergence_maps = convert_shells_to_convergence(
+        shell_maps, shell_redshifts, source_redshift, mock_cosmology
+    )
+    
+    # Check output shape
+    assert convergence_maps.shape == shell_maps.shape
+    
+    # Check that shells behind source have zero convergence
+    assert jnp.all(convergence_maps[shell_redshifts >= source_redshift] == 0)
+    
+    # Check that shells in front of source have non-zero convergence
+    in_front = shell_redshifts < source_redshift
+    assert jnp.all(convergence_maps[in_front] > 0)
+
+
+def test_empty_shell_handling():
+    """Test handling of empty shells."""
+    # Create particles all at one distance
+    positions = jnp.array([[10, 0, 0], [10, 1, 0], [10, 0, 1]])
+    masses = jnp.array([1e10, 1e10, 1e10])
+    observer = jnp.array([0, 0, 0])
+    
+    # Create shell that doesn't contain any particles
+    shell_map = _bin_particles_to_shell(
+        positions, masses, observer, 50.0, 1.0, nside=8
+    )
+    
+    # Should be all zeros
+    assert jnp.all(shell_map == 0)
+
+
+def test_shell_thickness_effect(mock_particles):
+    """Test that shell thickness affects particle selection."""
+    positions, masses = mock_particles
+    observer = jnp.array([0, 0, 0])
+    
+    # Create shells with different thicknesses
+    thin_shell = _bin_particles_to_shell(
+        positions, masses, observer, 50.0, 1.0, nside=8
+    )
+    thick_shell = _bin_particles_to_shell(
+        positions, masses, observer, 50.0, 20.0, nside=8
+    )
+    
+    # Thick shell should capture more particles
+    assert jnp.sum(thick_shell) > jnp.sum(thin_shell)
+
+
+@pytest.mark.parametrize("nside", [4, 8, 16])
+def test_different_nside_values(mock_particles, nside):
+    """Test that different nside values work correctly."""
+    positions, masses = mock_particles
+    observer = jnp.array([0, 0, 0])
+    
+    shell_map = _bin_particles_to_shell(
+        positions, masses, observer, 50.0, 10.0, nside=nside
+    )
+    
+    # Check correct output size
+    expected_npix = 12 * nside**2
+    assert shell_map.shape == (expected_npix,)
+    
+    # Check that we have some non-zero pixels
+    assert jnp.sum(shell_map > 0) > 0
+
+
+def test_observer_position_effect():
+    """Test that observer position affects the results."""
+    # Create a simple particle distribution
+    positions = jnp.array([[10, 0, 0], [20, 0, 0], [30, 0, 0]])
+    masses = jnp.array([1e10, 1e10, 1e10])
+    
+    # Two different observer positions
+    observer1 = jnp.array([0, 0, 0])
+    observer2 = jnp.array([5, 0, 0])
+    
+    shell_map1 = _bin_particles_to_shell(
+        positions, masses, observer1, 20.0, 5.0, nside=8
+    )
+    shell_map2 = _bin_particles_to_shell(
+        positions, masses, observer2, 20.0, 5.0, nside=8
+    )
+    
+    # Results should be different
+    assert not jnp.allclose(shell_map1, shell_map2)


### PR DESCRIPTION
Implements JAX code for binning dark matter particles from N-body simulations  onto spherical shells and outputting as HEALPix maps for ray tracing.

Features:
- create_density_shells_from_particles() for distance-based binning
- create_shells_from_lightcone() for redshift-based binning  
- convert_shells_to_convergence() for lensing calculations
- HEALPix map output with healpy integration
- JAX-accelerated implementation with JIT compilation
- Comprehensive tests and examples

Addresses #3